### PR TITLE
Add toggleable mobile navigation menu

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import logo from '../assets/images/logo-d10s.svg';
-import CtaButton from './CtaButton';
 
 const Header = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleLinkClick = () => {
+    setIsOpen(false);
+  };
+
   return (
     <header className="sticky top-0 bg-blanco border-b border-gris z-50">
       <div className="max-w-5xl mx-auto flex items-center justify-between p-4">
@@ -10,14 +15,33 @@ const Header = () => {
           <img src={logo} alt="Logo D10$" className="h-8 w-8" />
           <span className="font-bold text-azul">D10$</span>
         </a>
-        <nav className="hidden md:flex space-x-6 text-azul font-medium">
-          <a href="#">Inicio</a>
-          <a href="#about">Acerca</a>
-          <a href="#buy">Comprar</a>
+        <nav
+          className={`${isOpen ? 'block' : 'hidden'} md:flex space-y-2 md:space-y-0 md:space-x-6 text-azul font-medium`}
+        >
+          <a href="#" onClick={handleLinkClick}>
+            Inicio
+          </a>
+          <a href="#about" onClick={handleLinkClick}>
+            Acerca
+          </a>
+          <a href="#buy" onClick={handleLinkClick}>
+            Comprar
+          </a>
         </nav>
-        <div className="md:hidden">
-          <CtaButton href="#buy">Comprar</CtaButton>
-        </div>
+        <button
+          className="md:hidden text-azul"
+          onClick={() => setIsOpen(!isOpen)}
+          aria-label="Toggle navigation menu"
+        >
+          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          </svg>
+        </button>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- replace static header navigation with toggleable hamburger menu
- manage navigation visibility with React state and close menu on link selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec338c270832d877efe9843d5909c