### PR TITLE
Add Vitest setup and example test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests\""
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -18,6 +18,9 @@
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
-    "vite": "^4.4.0"
+    "vite": "^4.4.0",
+    "vitest": "^0.34.0",
+    "@testing-library/react": "^14.0.0",
+    "jsdom": "^22.1.0"
   }
 }

--- a/src/__tests__/CtaButton.test.jsx
+++ b/src/__tests__/CtaButton.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import CtaButton from '../components/CtaButton';
+
+describe('CtaButton', () => {
+  it('applies primary styles by default', () => {
+    render(<CtaButton href="/link">Click</CtaButton>);
+    const link = screen.getByRole('link', { name: /click/i });
+    expect(link.className).toContain('bg-dorado');
+  });
+
+  it('opens external links in new tab', () => {
+    render(<CtaButton href="http://example.com">External</CtaButton>);
+    const link = screen.getByRole('link', { name: /external/i });
+    expect(link.getAttribute('target')).toBe('_blank');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Vitest with React and jsdom
- add CtaButton component unit tests
- update package.json test script and dev dependencies

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec34e3e1c832d853cbe398af1f774